### PR TITLE
ESP32 interrupts

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@
 
 [platformio]
 default_envs = 
-   d1_mini
+   esp32dev
 
 [env]
 ; Global data for all [env:***]

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -201,7 +201,7 @@ class ISRReaction : public Reaction {
    * @param callback Interrupt callback. Keep this function short and add the
    * ICACHE_RAM_ATTR attribute.
    */
-  ISRReaction(uint32_t pin_number, int mode, const react_callback callback)
+  ISRReaction(uint8_t pin_number, int mode, const react_callback callback)
       : Reaction(callback),
         pin_number(pin_number),
         mode(mode) {


### PR DESCRIPTION
`onInterrupt` reaction callbacks had to be defined using the `ICACHE_RAM_ATTR` on ESP32, or else the CPU would crash if an interrupt occurred at the same time as flash access. I consider this to be a bug in the Arduino-ESP32 framework. As a fix, ISRReaction now uses the underlying esp32-idf to set the interrupts. These interrupts are disabled when flash is accessed, making also lambda callbacks safe to use.

ESP8266 functionality is maintained as is.