### PR TITLE
Wrap the library in a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Using ReactESP, the sketch can be rewritten to the following:
 ```cpp
 #include <ReactESP.h>
 
+using namespace reactesp;
+
 ReactESP app;
 
 setup() {
@@ -142,6 +144,8 @@ This solves Charlie's problem, but it's quite verbose. Using ReactESP, Charlie c
 ```c++
 #include <ReactESP.h>
 
+using namespace reactesp;
+
 ReactESP app;
 
 void setup() {
@@ -178,6 +182,21 @@ for (int i=0; i<20; i++) {
 ```
 
 ## API
+
+### Namespace use
+
+Note that beginning of ReactESP 2.0.0, the ReactESP library has been wrapped in
+a `reactesp` namespace.
+This is to avoid name conflicts with other libraries.
+
+The impact to the user is that they need to define the namespace when using the library.
+This can be done either globally by placing the following statement in the source code right after the `#include` statements:
+
+    using namespace reactesp;
+
+or by using the `reactesp::` prefix when using the library:
+
+    reactesp::ReactESP app;
 
 ### Event Registration Functions
 

--- a/examples/minimal/src/main.cpp
+++ b/examples/minimal/src/main.cpp
@@ -1,6 +1,8 @@
 #include <Arduino.h>
 #include <ReactESP.h>
 
+using namespace reactesp;
+
 #define LED_PIN 2
 
 int led_state = 0;

--- a/examples/torture_test/src/main.cpp
+++ b/examples/torture_test/src/main.cpp
@@ -1,6 +1,8 @@
 #include <Arduino.h>
 #include <ReactESP.h>
 
+using namespace reactesp;
+
 #define LED_PIN 2
 #define OUT_PIN 14 // D5
 #define INPUT_PIN1 12 // D6

--- a/src/ReactESP.cpp
+++ b/src/ReactESP.cpp
@@ -4,6 +4,8 @@
 #include <FunctionalInterrupt.h>
 #include <string.h>
 
+namespace reactesp {
+
 /**
  * @brief Return the current time since the device restart in microseconds
  *
@@ -184,3 +186,5 @@ TickReaction* ReactESP::onTick(const react_callback cb) {
   tre->add();
   return tre;
 }
+
+}  // namespace reactesp

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -7,6 +7,8 @@
 #include <functional>
 #include <queue>
 
+namespace reactesp {
+
 typedef std::function<void()> react_callback;
 typedef void (*isr_react_callback)(void*);
 
@@ -331,5 +333,7 @@ class ReactESP {
   void tickISR();
   void add(Reaction* re);
 };
+
+}  // namespace reactesp
 
 #endif


### PR DESCRIPTION
The ReactESP library code is now wrapped in a `reactesp` namespace. This avoids possible namespace collisions for any classes and types declared in the header file, but as a consequence, users will have to to define the namespace explicitly.