### PR TITLE
Support for running ReactESP simultaneously in multiple FreeRTOS tasks

### DIFF
--- a/src/ReactESP.cpp
+++ b/src/ReactESP.cpp
@@ -30,6 +30,7 @@ void TimedReaction::add(ReactESP* app) {
     Serial.println("Got a null pointer in TimedReaction::add");
     app = ReactESP::app;
   }
+  app_context = app;
   app->timed_queue.push(this);
 }
 
@@ -63,7 +64,7 @@ void RepeatReaction::tick() {
     this->last_trigger_time = now;
   }
   this->callback();
-  ReactESP::app->timed_queue.push(this);
+  app_context->timed_queue.push(this);
 }
 
 void UntimedReaction::add(ReactESP* app) {

--- a/src/ReactESP.cpp
+++ b/src/ReactESP.cpp
@@ -211,4 +211,8 @@ TickReaction* ReactESP::onTick(const react_callback cb) {
   return tre;
 }
 
+void ReactESP::remove(Reaction* reaction) {
+  reaction->remove(this);
+}
+
 }  // namespace reactesp

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -36,8 +36,8 @@ class Reaction {
    */
   Reaction(react_callback callback) : callback(callback) {}
   // FIXME: why do these have to be defined?
-  virtual void add() = 0;
-  virtual void remove() = 0;
+  virtual void add(ReactESP* app = nullptr) = 0;
+  virtual void remove(ReactESP* app = nullptr) = 0;
   virtual void tick() = 0;
 };
 
@@ -76,8 +76,8 @@ class TimedReaction : public Reaction {
 
   virtual ~TimedReaction() {}
   bool operator<(const TimedReaction& other);
-  void add();
-  void remove();
+  void add(ReactESP* app = nullptr) override;
+  void remove(ReactESP* app = nullptr) override;
   uint32_t getTriggerTime() { return (last_trigger_time + interval) / 1000; }
   uint64_t getTriggerTimeMicros() { return (last_trigger_time + interval); }
   bool isEnabled() { return enabled; }
@@ -142,8 +142,8 @@ class UntimedReaction : public Reaction {
  public:
   UntimedReaction(const react_callback callback) : Reaction(callback) {}
   virtual ~UntimedReaction() {}
-  virtual void add();
-  virtual void remove();
+  virtual void add(ReactESP* app = nullptr) override;
+  virtual void remove(ReactESP* app = nullptr) override;
   virtual void tick() = 0;
 };
 
@@ -204,9 +204,7 @@ class ISRReaction : public Reaction {
    * ICACHE_RAM_ATTR attribute.
    */
   ISRReaction(uint8_t pin_number, int mode, const react_callback callback)
-      : Reaction(callback),
-        pin_number(pin_number),
-        mode(mode) {
+      : Reaction(callback), pin_number(pin_number), mode(mode) {
 #ifdef ESP32
     gpio_int_type_t intr_type;
     switch (mode) {
@@ -233,8 +231,8 @@ class ISRReaction : public Reaction {
 #endif
   }
   virtual ~ISRReaction() {}
-  void add();
-  void remove();
+  void add(ReactESP* app = nullptr) override;
+  void remove(ReactESP* app = nullptr) override;
   void tick() {}
 };
 

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -195,7 +195,7 @@ class ISRReaction : public Reaction {
   static bool isr_service_installed;
   static void isr(void* arg);
 #endif
-  
+
  public:
   /**
    * @brief Construct a new ISRReaction object
@@ -327,6 +327,13 @@ class ReactESP {
    */
   TickReaction* onTick(const react_callback cb);
 
+  /**
+   * @brief Remove a reaction from the list of active reactions
+   *
+   * @param reaction Reaction to remove
+   */
+  void remove(Reaction* reaction);
+  
  private:
   std::priority_queue<TimedReaction*, std::vector<TimedReaction*>,
                       TriggerTimeCompare>

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -49,6 +49,8 @@ class TimedReaction : public Reaction {
   const uint64_t interval;
   uint64_t last_trigger_time;
   bool enabled;
+  // A repeat reaction needs to know which app it belongs to
+  ReactESP* app_context = nullptr;
 
  public:
   /**

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -251,9 +251,15 @@ class ReactESP {
 
  public:
   /**
-   * @brief Construct a new ReactESP object
+   * @brief Construct a new ReactESP object.
+   *
+   * @param singleton If true, set the singleton instance to this object
    */
-  ReactESP() { app = this; }
+  ReactESP(bool singleton = true) {
+    if (singleton) {
+      app = this;
+    }
+  }
   void tick(void);
 
   /// Static singleton reference to the instantiated ReactESP object


### PR DESCRIPTION
It is now possible to instantiate a task-specific ReactESP object without overwriting the default simpleton object. This allows TimedReactions to be used for controlling the program flow in independent FreeRTOS tasks.