### PR TITLE
Rename classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .vscode/launch.json
 .vscode/*
 .history
+managed_components

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An asynchronous programming and event loop library for the ESP32 and other micro
 
 The library is at the core of the [SensESP](https://github.com/SignalK/SensESP) project but is completely generic and can be used for standalone projects without issues.
 
-This library gets much of its inspiration (and some code) from [`Reactduino`](https://github.com/Reactduino/Reactduino). `ReactESP`, however, has been internally re-implemented for maintainability and readability, and has significantly better performance when there are lots of defined reactions. It also supports arbitrary callables as callbacks, allowing parametric creation of callback functions.
+This library gets much of its inspiration (and some code) from [`Reactduino`](https://github.com/Reactduino/Reactduino). `ReactESP`, however, has been internally re-implemented for maintainability and readability, and has significantly better performance when there are lots of defined events. It also supports arbitrary callables as callbacks, allowing parametric creation of callback functions.
 
 ## Blink
 
@@ -37,25 +37,25 @@ Using ReactESP, the sketch can be rewritten to the following:
 
 using namespace reactesp;
 
-ReactESP app;
+EventLoop event_loop;
 
 setup() {
   pinMode(LED_BUILTIN, OUTPUT);
 
-  app.onRepeat(1000, [] () {
+  event_loop.onRepeat(1000, [] () {
       static bool state = false;
       digitalWrite(LED_BUILTIN, state = !state);
   });
 }
 
 void loop() {
-  app.tick();
+  event_loop.tick();
 }
 ```
 
-Instead of directly defining the program logic in the `loop()` function, _reactions_ are defined in the `setup()` function. An event is a function that is executed when a certain event happens. In this case, the event is that the function should repeat every second, as defined by the `onRepeat()` method call. The second argument to the `onRepeat()` method is a [lambda function](http://en.cppreference.com/w/cpp/language/lambda) that is executed every time the reaction is triggered. If the syntax feels weird, you can also use regular named functions instead of lambdas.
+Instead of directly defining the program logic in the `loop()` function, _events_ are defined in the `setup()` function. An event is a function that is executed when a certain event happens. In this case, the event is that the function should repeat every second, as defined by the `onRepeat()` method call. The second argument to the `onRepeat()` method is a [lambda function](http://en.cppreference.com/w/cpp/language/lambda) that is executed every time the event is triggered. If the syntax feels weird, you can also use regular named functions instead of lambdas.
 
-The `app.tick()` call in the `loop()` function is the main loop of the program. It is responsible for calling the reactions that have been defined. You can also add additional code to the `loop()` function, any delays or other long-executing code should be avoided.
+The `event_loop.tick()` call in the `loop()` function is the main loop of the program. It is responsible for calling the events that have been defined. You can also add additional code to the `loop()` function, any delays or other long-executing code should be avoided.
 
 ## Why Bother?
 
@@ -146,28 +146,28 @@ This solves Charlie's problem, but it's quite verbose. Using ReactESP, Charlie c
 
 using namespace reactesp;
 
-EventLoop app;
+EventLoop event_loop;
 
 void setup() {
   Serial.begin(9600);
   pinMode(LED_BUILTIN, OUTPUT);
 
-  app.onAvailable(&Serial, [] () {
+  event_loop.onAvailable(&Serial, [] () {
     Serial.write(Serial.read());
     digitalWrite(LED_BUILTIN, HIGH);
 
-    app.onDelay(1000, [] () { digitalWrite(LED_BUILTIN, LOW); });
+    event_loop.onDelay(1000, [] () { digitalWrite(LED_BUILTIN, LOW); });
   });
 }
 
 void loop() {
-  app.tick();
+  event_loop.tick();
 }
 ```
 
 ## Advanced callback support
 
-Callbacks can be not just void pointers but any callable supported by `std::function`. This means they can use lambda captures or argument binding using `std::bind`. For example, the following code creates 20 different repeating reactions updating different fields of an array:
+Callbacks can be not just void pointers but any callable supported by `std::function`. This means they can use lambda captures or argument binding using `std::bind`. For example, the following code creates 20 different repeating events updating different fields of an array:
 
 ```c++
 static int timer_ticks[20];
@@ -175,7 +175,7 @@ static int timer_ticks[20];
 for (int i=0; i<20; i++) {
   timer_ticks[i] = 0;
   int delay = (i+1)*(i+1);
-  app.onRepeat(delay, [i]() {
+  event_loop.onRepeat(delay, [i]() {
     timer_ticks[i]++;
   });
 }
@@ -196,39 +196,39 @@ This can be done either globally by placing the following statement in the sourc
 
 This shouldn't be done in header files, however! Alternatively, the `reactesp::` prefix can be used when using the library:
 
-    reactesp::EventLoop app;
+    reactesp::EventLoop event_loop;
 
 ### Event Registration Functions
 
 All of the registration functions return an `Event` object pointer. This can be used to store and manipulate
-the reaction. `react_callback` is a typedef for `std::function<void()>` and can therefore be any callable supported by the C++ standard template library.
+the event. `react_callback` is a typedef for `std::function<void()>` and can therefore be any callable supported by the C++ standard template library.
 
 ```cpp
-DelayEvent app.onDelay(uint32_t t, react_callback cb);
+DelayEvent event_loop.onDelay(uint32_t t, react_callback cb);
 ```
 
 Delay the executation of a callback by `t` milliseconds.
 
 ```cpp
-RepeatEvent app.onRepeat(uint32_t t, react_callback cb);
+RepeatEvent event_loop.onRepeat(uint32_t t, react_callback cb);
 ```
 
 Repeatedly execute a callback every `t` milliseconds.
 
 ```cpp
-StreamEvent app.onAvailable(Stream *stream, react_callback cb);
+StreamEvent event_loop.onAvailable(Stream *stream, react_callback cb);
 ```
 
 Execute a callback when there is data available to read on an input stream (such as `&Serial`).
 
 ```cpp
-ISREvent app.onInterrupt(uint8_t pin_number, int mode, react_callback cb);
+ISREvent event_loop.onInterrupt(uint8_t pin_number, int mode, react_callback cb);
 ```
 
 Execute a callback when an interrupt number fires. This uses the same API as the `attachInterrupt()` Arduino function.
 
 ```cpp
-TickEvent app.onTick(react_callback cb);
+TickEvent event_loop.onTick(react_callback cb);
 ```
 
 Execute a callback on every tick of the event loop.
@@ -247,13 +247,19 @@ Remove the event from the execution queue.
 
 - [`Minimal`](examples/minimal/src/main.cpp): A minimal example with two timers switching the LED state.
 
-- [`Torture test`](examples/torture_test/src/main.cpp): A stress test of twenty simultaneous repeat reactions as well as a couple of interrupts, a stream, and a tick reaction. For kicks, try changing `NUM_TIMERS` to 200. Program performance will be practically unchanged!
+- [`Torture test`](examples/torture_test/src/main.cpp): A stress test of twenty simultaneous repeat events as well as a couple of interrupts, a stream, and a tick event. For kicks, try changing `NUM_TIMERS` to 200. Program performance will be practically unchanged!
+
+## Changes between version 2 and 3
+
+- Renamed classes from ReactESP to EventLoop and from *Reaction to *Event to better
+  reflect their purpose.
+- Removed the `app` singleton. The user is now responsible for maintaining the EventLoop object.
 
 ## Changes between version 1 and 2
 
 ReactESP version 2 has changed the software initialization approach from version 1.
 Version 1 implemented the Arduino framework standard `setup()` and `loop()` functions behind the scenes,
-and a user just instantiated a ReactESP object and provided a setup function as an argument:
+and a user just instantiated an EventLoop object and provided a setup function as an argument:
 
     ReactESP app([]() {
         app.onDelay(...);

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 By [Matti Airas](https://github.com/mairas)
 
-An asynchronous programming library for the ESP32 and other microcontrollers using the Arduino framework.
+An asynchronous programming and event loop library for the ESP32 and other microcontrollers using the Arduino framework.
 
 The library is at the core of the [SensESP](https://github.com/SignalK/SensESP) project but is completely generic and can be used for standalone projects without issues.
 
@@ -53,7 +53,7 @@ void loop() {
 }
 ```
 
-Instead of directly defining the program logic in the `loop()` function, _reactions_ are defined in the `setup()` function. A reaction is a function that is executed when a certain event happens. In this case, the event is that the function should repeat every second, as defined by the `onRepeat()` method call. The second argument to the `onRepeat()` method is a [lambda function](http://en.cppreference.com/w/cpp/language/lambda) that is executed every time the reaction is triggered. If the syntax feels weird, you can also use regular named functions instead of lambdas.
+Instead of directly defining the program logic in the `loop()` function, _reactions_ are defined in the `setup()` function. An event is a function that is executed when a certain event happens. In this case, the event is that the function should repeat every second, as defined by the `onRepeat()` method call. The second argument to the `onRepeat()` method is a [lambda function](http://en.cppreference.com/w/cpp/language/lambda) that is executed every time the reaction is triggered. If the syntax feels weird, you can also use regular named functions instead of lambdas.
 
 The `app.tick()` call in the `loop()` function is the main loop of the program. It is responsible for calling the reactions that have been defined. You can also add additional code to the `loop()` function, any delays or other long-executing code should be avoided.
 
@@ -146,7 +146,7 @@ This solves Charlie's problem, but it's quite verbose. Using ReactESP, Charlie c
 
 using namespace reactesp;
 
-ReactESP app;
+EventLoop app;
 
 void setup() {
   Serial.begin(9600);
@@ -194,41 +194,41 @@ This can be done either globally by placing the following statement in the sourc
 
     using namespace reactesp;
 
-or by using the `reactesp::` prefix when using the library:
+This shouldn't be done in header files, however! Alternatively, the `reactesp::` prefix can be used when using the library:
 
-    reactesp::ReactESP app;
+    reactesp::EventLoop app;
 
 ### Event Registration Functions
 
-All of the registration functions return a `Reaction` object pointer. This can be used to store and manipulate
+All of the registration functions return an `Event` object pointer. This can be used to store and manipulate
 the reaction. `react_callback` is a typedef for `std::function<void()>` and can therefore be any callable supported by the C++ standard template library.
 
 ```cpp
-DelayReaction app.onDelay(uint32_t t, react_callback cb);
+DelayEvent app.onDelay(uint32_t t, react_callback cb);
 ```
 
 Delay the executation of a callback by `t` milliseconds.
 
 ```cpp
-RepeatReaction app.onRepeat(uint32_t t, react_callback cb);
+RepeatEvent app.onRepeat(uint32_t t, react_callback cb);
 ```
 
 Repeatedly execute a callback every `t` milliseconds.
 
 ```cpp
-StreamReaction app.onAvailable(Stream *stream, react_callback cb);
+StreamEvent app.onAvailable(Stream *stream, react_callback cb);
 ```
 
 Execute a callback when there is data available to read on an input stream (such as `&Serial`).
 
 ```cpp
-ISRReaction app.onInterrupt(uint8_t pin_number, int mode, react_callback cb);
+ISREvent app.onInterrupt(uint8_t pin_number, int mode, react_callback cb);
 ```
 
 Execute a callback when an interrupt number fires. This uses the same API as the `attachInterrupt()` Arduino function.
 
 ```cpp
-TickReaction app.onTick(react_callback cb);
+TickEvent app.onTick(react_callback cb);
 ```
 
 Execute a callback on every tick of the event loop.
@@ -236,12 +236,12 @@ Execute a callback on every tick of the event loop.
 ### Management functions
 
 ```cpp
-void Reaction::remove();
+void Event::remove();
 ```
 
-Remove the reaction from the execution queue.
+Remove the event from the execution queue.
 
-*Note*: Calling `remove()` for `DelayReaction` objects is only safe if the reaction has not been triggered yet. Upon triggering, the `DelayReaction` object is deleted and any pointers to it will be invalidated.
+*Note*: Calling `remove()` for `DelayEvent` objects is only safe if the event has not been triggered yet. Upon triggering, the `DelayEvent` object is deleted and any pointers to it will be invalidated.
 
 ### Examples
 

--- a/examples/minimal/src/main.cpp
+++ b/examples/minimal/src/main.cpp
@@ -7,29 +7,29 @@ using namespace reactesp;
 
 int led_state = 0;
 
-ReactESP app;
+EventLoop event_loop;
 
 void setup() {
   Serial.begin(115200);
   Serial.println("Starting");
   pinMode(LED_PIN, OUTPUT);
-  
-  Serial.println("Setting up timed reactions");
+
+  Serial.println("Setting up timed events");
 
   // toggle LED every 400 ms
-  app.onRepeat(400, [] () {
+  event_loop.onRepeat(400, [] () {
     led_state = !led_state;
     digitalWrite(LED_PIN, led_state);
   });
 
   // Additionally, toggle LED every 1020 ms.
   // This adds an irregularity to the LED blink pattern.
-  app.onRepeat(1020, [] () {
+  event_loop.onRepeat(1020, [] () {
     led_state = !led_state;
     digitalWrite(LED_PIN, led_state);
-  });  
+  });
 }
 
 void loop() {
-  app.tick();
+  event_loop.tick();
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@
 ; framework = arduino
 
 [platformio]
-default_envs = 
+default_envs =
    esp32dev
 
 [env]
@@ -39,12 +39,11 @@ build_flags =
    -D LED_BUILTIN=2
 board_build.f_cpu = 160000000L
 upload_resetmethod = nodemcu
-upload_speed = 460800  
+upload_speed = 460800
 
 [espressif32_base]
 ;this section has config items common to all ESP32 boards
 platform = espressif32
-build_unflags = -Werror=reorder
 board_build.partitions = min_spiffs.csv
 monitor_filters = esp32_exception_decoder
 

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -16,11 +16,6 @@ using isr_react_callback = void (*)(void*);
 
 class ReactESP;
 
-// ESP32 doesn't have the micros64 function defined
-#ifdef ESP32
-uint64_t ICACHE_RAM_ATTR micros64();
-#endif
-
 /**
  * @brief Reactions are code to be called when a given condition is fulfilled
  */
@@ -89,7 +84,7 @@ class TimedReaction : public Reaction {
   TimedReaction(uint64_t interval, react_callback callback)
       : Reaction(callback),
         interval(interval),
-        last_trigger_time(micros64()),
+        last_trigger_time(micros()),
         enabled(true) {}
 
   bool operator<(const TimedReaction& other) const;

--- a/src/ReactESP.h
+++ b/src/ReactESP.h
@@ -361,6 +361,18 @@ class EventLoop {
   void add(Event* re);
 };
 
+// Provide compatibility aliases for the old naming scheme
+
+using ReactESP = EventLoop;
+using TimedReaction = TimedEvent;
+using UntimedReaction = UntimedEvent;
+using DelayReaction = DelayEvent;
+using RepeatReaction = RepeatEvent;
+using ISRReaction = ISREvent;
+using StreamReaction = StreamEvent;
+using TickReaction = TickEvent;
+
+
 }  // namespace reactesp
 
 #endif


### PR DESCRIPTION
Given that at its core ReactESP implements an async event loop, the implementation class names could be clearer. This PR renames the classes as follows:

```
ReactESP -> EventLoop
*Reaction -> *Event
```

The old names are still provided for compatibility.

Additionally, this PR also removes the singleton functionality. The user is now responsible for maintaining the event loop pointer. I intended to propose this in a separate PR but accidentally squashed the PRs and only noticed it after quite a bit of git history mangling.