### PR TITLE
Replace priority_queue with std::set for immediate timed event removal

### DIFF
--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -7,26 +7,20 @@ namespace reactesp {
 void EventLoop::tickTimed() {
   xSemaphoreTakeRecursive(timed_queue_mutex_, portMAX_DELAY);
   const uint64_t now = micros64();
-  TimedEvent* top = nullptr;
 
-  while (true) {
-    if (timed_queue.empty()) {
+  while (!timed_events_.empty()) {
+    auto it = timed_events_.begin();
+    TimedEvent* event = *it;
+    if (now < event->getTriggerTimeMicros()) {
       break;
     }
-    top = timed_queue.top();
-    if (!top->isEnabled()) {
-      timed_queue.pop();
-      delete top;
-      continue;
-    }
-    const uint64_t trigger_t = top->getTriggerTimeMicros();
-    if (now >= trigger_t) {
-      timed_queue.pop();
-      top->tick(this);
-      timed_event_counter++;
-    } else {
-      break;
-    }
+    timed_events_.erase(it);
+    xSemaphoreGiveRecursive(timed_queue_mutex_);
+    // tick() may re-insert the event (RepeatEvent) or delete it
+    // (DelayEvent), and may call back into the event loop.
+    event->tick(this);
+    timed_event_counter++;
+    xSemaphoreTakeRecursive(timed_queue_mutex_, portMAX_DELAY);
   }
   xSemaphoreGiveRecursive(timed_queue_mutex_);
 }

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -14,13 +14,25 @@ void EventLoop::tickTimed() {
     if (now < event->getTriggerTimeMicros()) {
       break;
     }
-    timed_events_.erase(it);
+    // Extract the node to avoid heap deallocation. RepeatEvent::tick()
+    // will update the trigger time; we reinsert the same node afterward.
+    auto node = timed_events_.extract(it);
     xSemaphoreGiveRecursive(timed_queue_mutex_);
-    // tick() may re-insert the event (RepeatEvent) or delete it
-    // (DelayEvent), and may call back into the event loop.
+    // tick() may call back into the event loop. For RepeatEvent, tick()
+    // updates the trigger time. For DelayEvent, tick() sets enabled=false.
+    // Either type's callback may call remove(), which also sets
+    // enabled=false.
     event->tick(this);
     timed_event_counter++;
     xSemaphoreTakeRecursive(timed_queue_mutex_, portMAX_DELAY);
+    if (event->isEnabled() && !node.empty()) {
+      // RepeatEvent: reinsert the extracted node without allocation.
+      timed_events_.insert(std::move(node));
+    } else {
+      // DelayEvent (done) or RepeatEvent removed from within its
+      // callback: drop the node and delete the event.
+      delete event;
+    }
   }
   xSemaphoreGiveRecursive(timed_queue_mutex_);
 }

--- a/src/event_loop.h
+++ b/src/event_loop.h
@@ -132,7 +132,11 @@ class EventLoop {
   // pointer tiebreaker for total ordering). This allows O(log n) removal of
   // specific events, avoiding the zombie-event accumulation that occurred
   // with the previous priority_queue + lazy-delete approach.
-  std::set<TimedEvent*, TriggerTimeCompare> timed_events_;
+  // The hot path uses C++17 extract()/insert() to reuse tree nodes without
+  // heap allocation.
+  using TimedEventSet = std::set<TimedEvent*, TriggerTimeCompare>;
+  using TimedEventNode = TimedEventSet::node_type;
+  TimedEventSet timed_events_;
   // Untimed events are stored in a vector, which is traversed in order.
   // Elements are rarely removed from the middle of the list, so a vector is
   // acceptable.

--- a/src/event_loop.h
+++ b/src/event_loop.h
@@ -1,7 +1,7 @@
 #ifndef REACTESP_SRC_EVENT_LOOP_H_
 #define REACTESP_SRC_EVENT_LOOP_H_
 
-#include <queue>
+#include <set>
 
 #include "events.h"
 
@@ -23,7 +23,7 @@ class EventLoop {
    * @brief Construct a new EventLoop object.
    */
   EventLoop()
-      : timed_queue(), untimed_list(), isr_event_list() {
+      : timed_events_(), untimed_list(), isr_event_list() {
     timed_queue_mutex_ = xSemaphoreCreateRecursiveMutex();
     untimed_list_mutex_ = xSemaphoreCreateRecursiveMutex();
     isr_event_list_mutex_ = xSemaphoreCreateRecursiveMutex();
@@ -39,7 +39,7 @@ class EventLoop {
   EventLoop(const EventLoop&) = delete;
   EventLoop(EventLoop&&) = delete;
 
-  int getTimedEventQueueSize() { return timed_queue.size(); }
+  int getTimedEventQueueSize() { return timed_events_.size(); }
   int getUntimedEventQueueSize() { return untimed_list.size(); }
   int getISREventQueueSize() { return isr_event_list.size(); }
   int getEventQueueSize() {
@@ -128,11 +128,11 @@ class EventLoop {
   void remove(Event* event);
 
  protected:
-  // Timed events are stored in a priority queue, sorted by trigger time. It
-  // pretty much always suffices to just access the top element of the queue.
-  // Element removal is always done by invalidating the element.
-  std::priority_queue<TimedEvent*, std::vector<TimedEvent*>, TriggerTimeCompare>
-      timed_queue;
+  // Timed events are stored in an ordered set, sorted by trigger time (with
+  // pointer tiebreaker for total ordering). This allows O(log n) removal of
+  // specific events, avoiding the zombie-event accumulation that occurred
+  // with the previous priority_queue + lazy-delete approach.
+  std::set<TimedEvent*, TriggerTimeCompare> timed_events_;
   // Untimed events are stored in a vector, which is traversed in order.
   // Elements are rarely removed from the middle of the list, so a vector is
   // acceptable.

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -50,7 +50,8 @@ DelayEvent::DelayEvent(uint64_t delay, react_callback callback)
 void DelayEvent::tick(EventLoop* event_loop) {
   this->last_trigger_time = micros64();
   this->callback();
-  delete this;
+  // Mark as done — tickTimed() will drop the node and delete this event.
+  this->enabled = false;
 }
 
 void RepeatEvent::tick(EventLoop* event_loop) {
@@ -61,15 +62,9 @@ void RepeatEvent::tick(EventLoop* event_loop) {
     this->last_trigger_time = now;
   }
   this->callback();
-  // The callback may have called remove() on this event. If so,
-  // enabled is now false — delete instead of re-inserting.
-  if (this->enabled) {
-    xSemaphoreTakeRecursive(event_loop->timed_queue_mutex_, portMAX_DELAY);
-    event_loop->timed_events_.insert(this);
-    xSemaphoreGiveRecursive(event_loop->timed_queue_mutex_);
-  } else {
-    delete this;
-  }
+  // If the callback called remove(), enabled is now false.
+  // tickTimed() checks isEnabled() and handles reinsertion or
+  // deletion accordingly.
 }
 
 void UntimedEvent::add(EventLoop* event_loop) {

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -16,14 +16,25 @@ bool TimedEvent::operator<(const TimedEvent& other) const {
 
 void TimedEvent::add(EventLoop* event_loop) {
   xSemaphoreTakeRecursive(event_loop->timed_queue_mutex_, portMAX_DELAY);
-  event_loop->timed_queue.push(this);
+  event_loop->timed_events_.insert(this);
   xSemaphoreGiveRecursive(event_loop->timed_queue_mutex_);
 }
 
 void TimedEvent::remove(EventLoop* event_loop) {
-  this->enabled = false;
-  // the object will be deleted when it's popped out of the
-  // timer queue
+  xSemaphoreTakeRecursive(event_loop->timed_queue_mutex_, portMAX_DELAY);
+  auto it = event_loop->timed_events_.find(this);
+  if (it != event_loop->timed_events_.end()) {
+    // Event is in the container — erase and delete immediately.
+    event_loop->timed_events_.erase(it);
+    xSemaphoreGiveRecursive(event_loop->timed_queue_mutex_);
+    delete this;
+  } else {
+    // Event is currently being ticked (popped from the container but
+    // not yet re-inserted). Signal tick() to delete it instead of
+    // re-inserting.
+    this->enabled = false;
+    xSemaphoreGiveRecursive(event_loop->timed_queue_mutex_);
+  }
 }
 
 DelayEvent::DelayEvent(uint32_t delay, react_callback callback)
@@ -43,7 +54,6 @@ void DelayEvent::tick(EventLoop* event_loop) {
 }
 
 void RepeatEvent::tick(EventLoop* event_loop) {
-  xSemaphoreTakeRecursive(event_loop->timed_queue_mutex_, portMAX_DELAY);
   auto now = micros64();
   this->last_trigger_time = this->last_trigger_time + this->interval;
   if (this->last_trigger_time + this->interval < now) {
@@ -51,8 +61,15 @@ void RepeatEvent::tick(EventLoop* event_loop) {
     this->last_trigger_time = now;
   }
   this->callback();
-  event_loop->timed_queue.push(this);
-  xSemaphoreGiveRecursive(event_loop->timed_queue_mutex_);
+  // The callback may have called remove() on this event. If so,
+  // enabled is now false — delete instead of re-inserting.
+  if (this->enabled) {
+    xSemaphoreTakeRecursive(event_loop->timed_queue_mutex_, portMAX_DELAY);
+    event_loop->timed_events_.insert(this);
+    xSemaphoreGiveRecursive(event_loop->timed_queue_mutex_);
+  } else {
+    delete this;
+  }
 }
 
 void UntimedEvent::add(EventLoop* event_loop) {

--- a/src/events.h
+++ b/src/events.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 
 namespace reactesp {
 
@@ -117,11 +118,35 @@ class TimedEvent : public Event {
   uint64_t getTriggerTimeMicros() const {
     return (last_trigger_time + interval);
   }
+
+  /**
+   * @brief Check if the event is still active.
+   *
+   * An event is active unless it was removed while being ticked (i.e.,
+   * from within its own callback). In that case, tick() will delete the
+   * event instead of reinserting it.
+   */
   bool isEnabled() const { return enabled; }
 };
 
+/**
+ * @brief Strict total ordering for TimedEvent pointers.
+ *
+ * Orders by trigger time ascending. Pointer address is used as a
+ * tiebreaker so that distinct events with the same trigger time have
+ * a well-defined, unique position in an ordered container (std::set).
+ *
+ * Note: last_trigger_time (part of the sort key) must not be mutated
+ * while the event is inside the container — remove first, modify, then
+ * re-insert.
+ */
 struct TriggerTimeCompare {
-  bool operator()(TimedEvent* a, TimedEvent* b) { return *b < *a; }
+  bool operator()(const TimedEvent* a, const TimedEvent* b) const {
+    const uint64_t ta = a->getTriggerTimeMicros();
+    const uint64_t tb = b->getTriggerTimeMicros();
+    if (ta != tb) return ta < tb;
+    return std::less<const TimedEvent*>{}(a, b);
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary

- Replace `std::priority_queue` with `std::set` for the timed event container, enabling O(log n) immediate removal of specific events
- Eliminate the lazy-cleanup mechanism that allowed disabled `RepeatEvent` objects to accumulate and exhaust heap memory
- Handle the edge case where `remove()` is called from within a `tick()` callback (e.g., `RepeatStopping`) using the `enabled` flag as a cancellation signal

## Motivation

The previous `priority_queue` + lazy-delete design only freed disabled timed events when they reached the top of the queue. When callers repeatedly created and removed `RepeatEvent` objects (as SensESP's `Repeat` transforms do on every `set()`), disabled events accumulated proportional to `input_rate × repeat_interval`, eventually exhausting heap on ESP32.

Reported in SignalK/SensESP#953.

## Test plan

- [x] Build HALMET example firmware against this branch
- [x] Flash to physical HALMET device and verify normal operation
- [x] Confirm WiFi, Signal K WebSocket, analog/digital inputs, NMEA 2000, and 34+ RepeatExpiring transforms all function correctly
- [ ] Run existing torture_test example to verify event loop behavior under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)