### PR TITLE
fix(event_loop): unbreak 3.3.0 on C++14 toolchains (missing <vector> + node_type)

### DIFF
--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -14,9 +14,14 @@ void EventLoop::tickTimed() {
     if (now < event->getTriggerTimeMicros()) {
       break;
     }
+#if __cplusplus >= 201703L
     // Extract the node to avoid heap deallocation. RepeatEvent::tick()
     // will update the trigger time; we reinsert the same node afterward.
     auto node = timed_events_.extract(it);
+#else
+    // C++14 fallback: erase + reinsert, one allocation per RepeatEvent tick.
+    timed_events_.erase(it);
+#endif
     xSemaphoreGiveRecursive(timed_queue_mutex_);
     // tick() may call back into the event loop. For RepeatEvent, tick()
     // updates the trigger time. For DelayEvent, tick() sets enabled=false.
@@ -25,6 +30,7 @@ void EventLoop::tickTimed() {
     event->tick(this);
     timed_event_counter++;
     xSemaphoreTakeRecursive(timed_queue_mutex_, portMAX_DELAY);
+#if __cplusplus >= 201703L
     if (event->isEnabled() && !node.empty()) {
       // RepeatEvent: reinsert the extracted node without allocation.
       timed_events_.insert(std::move(node));
@@ -33,6 +39,13 @@ void EventLoop::tickTimed() {
       // callback: drop the node and delete the event.
       delete event;
     }
+#else
+    if (event->isEnabled()) {
+      timed_events_.insert(event);
+    } else {
+      delete event;
+    }
+#endif
   }
   xSemaphoreGiveRecursive(timed_queue_mutex_);
 }

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -19,7 +19,8 @@ void EventLoop::tickTimed() {
     // will update the trigger time; we reinsert the same node afterward.
     auto node = timed_events_.extract(it);
 #else
-    // C++14 fallback: erase + reinsert, one allocation per RepeatEvent tick.
+    // C++14 fallback: erase + reinsert, one heap alloc + dealloc per
+    // RepeatEvent tick.
     timed_events_.erase(it);
 #endif
     xSemaphoreGiveRecursive(timed_queue_mutex_);

--- a/src/event_loop.h
+++ b/src/event_loop.h
@@ -134,12 +134,9 @@ class EventLoop {
   // specific events, avoiding the zombie-event accumulation that occurred
   // with the previous priority_queue + lazy-delete approach.
   // The hot path uses C++17 extract()/insert() to reuse tree nodes without
-  // heap allocation; under C++14 it falls back to erase()/insert() with one
-  // allocation per RepeatEvent tick.
+  // heap allocation; under C++14 it falls back to erase()/insert(), which
+  // does one heap alloc + dealloc per RepeatEvent tick.
   using TimedEventSet = std::set<TimedEvent*, TriggerTimeCompare>;
-#if __cplusplus >= 201703L
-  using TimedEventNode = TimedEventSet::node_type;
-#endif
   TimedEventSet timed_events_;
   // Untimed events are stored in a vector, which is traversed in order.
   // Elements are rarely removed from the middle of the list, so a vector is

--- a/src/event_loop.h
+++ b/src/event_loop.h
@@ -2,6 +2,7 @@
 #define REACTESP_SRC_EVENT_LOOP_H_
 
 #include <set>
+#include <vector>
 
 #include "events.h"
 

--- a/src/event_loop.h
+++ b/src/event_loop.h
@@ -134,9 +134,12 @@ class EventLoop {
   // specific events, avoiding the zombie-event accumulation that occurred
   // with the previous priority_queue + lazy-delete approach.
   // The hot path uses C++17 extract()/insert() to reuse tree nodes without
-  // heap allocation.
+  // heap allocation; under C++14 it falls back to erase()/insert() with one
+  // allocation per RepeatEvent tick.
   using TimedEventSet = std::set<TimedEvent*, TriggerTimeCompare>;
+#if __cplusplus >= 201703L
   using TimedEventNode = TimedEventSet::node_type;
+#endif
   TimedEventSet timed_events_;
   // Untimed events are stored in a vector, which is traversed in order.
   // Elements are rarely removed from the middle of the list, so a vector is


### PR DESCRIPTION
## Summary

3.3.0 silently broke compilation on toolchains that default to C++14 — in particular the Arduino-Espressif `espressif32 @ ^6.x` platform, which a lot of downstream projects (e.g. SensESP) still build against. Two distinct issues:

1. **`event_loop.h` references `std::vector` without `#include <vector>`.** Some toolchains transitively pull `<vector>` via other headers and compile fine; the Arduino-Espressif v6.x toolchain does not, and fails with `'vector' in namespace 'std' does not name a template type`. This is an unambiguous bug independent of any C++ standard.

2. **The new perf optimization uses `std::set::extract()` / `insert(node_type)`, which is C++17-only.** The 3.2.0 → 3.3.0 changelog doesn't document a new minimum C++ standard, and there's no major version bump, so downstream `^3.2.0` constraints silently pull in the breaking change.

## What this PR does

- Adds the missing `#include <vector>` to `event_loop.h` (commit 1).
- Gates the node-reuse hot path on `__cplusplus >= 201703L`; under C++14 it falls back to a semantically equivalent `erase()` + `insert()` pair (commit 2). The fallback does one heap allocation per `RepeatEvent` tick — exactly the regression a C++14 user is implicitly opting into — but restores compilation on older toolchains without any public API change.

C++17 users lose nothing; C++14 users get a working build. The `TimedEventNode` typedef in the header is also `#if`-gated so the header itself parses under C++14.

## Why not just bump to 4.0.0 + document C++17 as required?

Reasonable alternative, and arguably cleaner. Choosing the compat path here because:
- The `<vector>` include is a clear bug regardless.
- The fallback is small and localized to one function (`EventLoop::tickTimed`).
- Avoids forcing every downstream to update version constraints.

If you'd prefer the 4.0.0 + documented C++17 route, happy to rework this to just the `<vector>` fix + a docs note.

## Verification

Tested against SensESP's CI matrix locally on a Pi 5:

- **arduino_esp32** (`espressif32 @ ^6.9.0`, C++14): previously failed with `'node_type' ... does not name a type` + `'vector' in namespace 'std' does not name a template type`. With this PR: `[PASSED]`.
- **pioarduino_esp32** (newer pioarduino platform, C++17/gnu++2a): builds via the existing C++17 hot path. `[PASSED]`.

Note: this is also blocking the latest CI on SignalK/SensESP — see https://github.com/SignalK/SensESP/actions/runs/26077887618 for the failing log, and https://github.com/SignalK/SensESP/pull/961 for the stopgap `~3.2.0` pin SensESP is using until a fixed ReactESP ships.